### PR TITLE
feat: add multi-format book download with correct MIME types

### DIFF
--- a/src/opds_server/api/catalog.py
+++ b/src/opds_server/api/catalog.py
@@ -6,8 +6,9 @@ from opds_server.services.opds import (
     generate_root_feed,
     generate_title_feed,
     generate_book_search_feed,
+    get_book_mime_type,
 )
-from opds_server.db.access import get_book_path, get_cover_path, get_book_title
+from opds_server.db.access import get_book_file_path, get_cover_path, get_book_title
 from fastapi.responses import FileResponse
 
 router = APIRouter()
@@ -24,15 +25,15 @@ def title_to_filename(title: str, extension: str = ".epub") -> str:
     return f"{title}{extension}"
 
 
-@router.get("/opds/book/{book_id}/file")
-def download_book(book_id: int) -> FileResponse:
-    path = get_book_path(book_id)
+@router.get("/opds/book/{book_id}/file/{file_format}")
+def download_book(book_id: int, file_format: str) -> FileResponse:
+    path = get_book_file_path(book_id, file_format)
     title = get_book_title(book_id)
     extension = path.suffix
     return FileResponse(
         path,
-        media_type=f"application/{extension}",
-        filename=title_to_filename(title, extension=f".{extension}"),
+        media_type=get_book_mime_type(file_format.upper()),
+        filename=title_to_filename(title, extension=extension),
     )
 
 

--- a/src/opds_server/api/catalog.py
+++ b/src/opds_server/api/catalog.py
@@ -14,15 +14,19 @@ from fastapi.responses import FileResponse
 router = APIRouter()
 
 
-def title_to_filename(title: str, extension: str = ".epub") -> str:
+def title_to_filename(title: str, extension: str) -> str:
     title = unicodedata.normalize("NFKD", title)
 
     title = re.sub(r'[\\/*?:"<>|]', "_", title)
 
-    title = re.sub(r"\s+", " ", title).strip()
+    title = re.sub(r"\s+", " ", title).strip(" .")
+
+    if not title:
+        title = "book"
+
     title = title[:100]  # можно подстроить по нужной длине
 
-    return f"{title}{extension}"
+    return f"{title}.{extension}"
 
 
 @router.get("/opds/book/{book_id}/file/{file_format}")

--- a/src/opds_server/api/catalog.py
+++ b/src/opds_server/api/catalog.py
@@ -27,13 +27,12 @@ def title_to_filename(title: str, extension: str = ".epub") -> str:
 
 @router.get("/opds/book/{book_id}/file/{file_format}")
 def download_book(book_id: int, file_format: str) -> FileResponse:
-    path = get_book_file_path(book_id, file_format)
+    path = get_book_file_path(book_id, file_format.upper())
     title = get_book_title(book_id)
-    extension = path.suffix
     return FileResponse(
         path,
         media_type=get_book_mime_type(file_format.upper()),
-        filename=title_to_filename(title, extension=extension),
+        filename=title_to_filename(title, extension=file_format.lower()),
     )
 
 

--- a/src/opds_server/db/access.py
+++ b/src/opds_server/db/access.py
@@ -74,7 +74,7 @@ def get_cover_path(book_id: int) -> Path:
         return cover
 
 
-def add_authors(books: list) -> list[dict]:
+def add_authors(books: list) -> dict[int, dict]:
     book_ids = [book[0] for book in books]
     with connect_db() as conn:
         cur = conn.cursor()
@@ -95,22 +95,20 @@ def add_authors(books: list) -> list[dict]:
         for book_id, author_id, name in cur.fetchall():
             authors_by_book[book_id].append({"id": author_id, "name": name})
 
-        result = []
+        result = {}
         for book_id, title, last_modified in books:
-            result.append(
-                {
-                    "id": book_id,
-                    "title": title,
-                    "last_modified": datetime.fromisoformat(last_modified),
-                    "authors": authors_by_book[book_id],
-                }
-            )
+            result[book_id] = {
+                "title": title,
+                "last_modified": datetime.fromisoformat(last_modified),
+                "authors": authors_by_book[book_id],
+            }
+
         return result
 
 
 def select_books(
     sql: str, page: int, limit: int = 10, parameters: list | None = None
-) -> tuple[list[dict], bool, bool]:
+) -> tuple[dict[int, dict], bool, bool]:
     with connect_db() as conn:
         cur = conn.cursor()
 
@@ -128,7 +126,7 @@ def select_books(
         return add_authors(books[:limit]), has_previous, has_next
 
 
-def get_recent_books(page: int, limit: int = 10) -> tuple[list[dict], bool, bool]:
+def get_recent_books(page: int, limit: int = 10) -> tuple[dict[int, dict], bool, bool]:
     sql = """
           SELECT id, title, last_modified
           FROM books
@@ -140,7 +138,7 @@ def get_recent_books(page: int, limit: int = 10) -> tuple[list[dict], bool, bool
 
 def search_books(
     query: str, page: int, limit: int = 10
-) -> tuple[list[dict], bool, bool]:
+) -> tuple[dict[int, dict], bool, bool]:
     sql = """
           SELECT id, title, last_modified
           FROM books

--- a/src/opds_server/db/access.py
+++ b/src/opds_server/db/access.py
@@ -34,21 +34,28 @@ def get_book_title(book_id: int) -> str:
         return row[0]
 
 
-def get_book_path(book_id: int) -> Path:
+def get_book_file_path(book_id: int, format: str) -> Path:
     with connect_db() as conn:
         cursor = conn.cursor()
+
+        # Fetch the folder path for the book
         cursor.execute("SELECT path FROM books WHERE id=?", (book_id,))
         row = cursor.fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="Book not found")
         folder = row[0]
 
-        cursor.execute("SELECT format, name FROM data WHERE book=?", (book_id,))
+        # Fetch the format and filename for the book
+        cursor.execute(
+            "SELECT name FROM data WHERE book=? AND format=?", (book_id, format)
+        )
         row2 = cursor.fetchone()
         if not row2:
             raise HTTPException(status_code=404, detail="Book file not found")
-        book_format, filename = row2
-        filename = Path(filename + "." + book_format.lower())
+        (filename,) = row2
+
+        filename = Path(filename + "." + format.lower())
+
         return Path(get_db_path().parent, folder, filename)
 
 

--- a/src/opds_server/services/opds.py
+++ b/src/opds_server/services/opds.py
@@ -75,8 +75,9 @@ def get_files_xml(book_id: int, files: list[dict]) -> str:
 
     files_xml = ""
     for file in files:
+        file_format = file["format"].lower()
         files_xml += f"""
-            <link rel="http://opds-spec.org/acquisition" type="{get_book_mime_type(file["format"].lower())}" href="/opds/book/{book_id}/file"/>"""
+            <link rel="http://opds-spec.org/acquisition" type="{get_book_mime_type(file_format)}" href="/opds/book/{book_id}/file/{file_format}"/>"""
     return files_xml
 
 
@@ -189,9 +190,7 @@ def items_from_books(books: dict[int, dict]) -> list[Item]:
                 updated_time=book["last_modified"],
                 author=book["authors"][0],
                 files=book["files"],
-                links=f"""
-            <link type="image/jpeg" href="/opds/book/{book_id}/cover" rel="http://opds-spec.org/image"/>
-            """,
+                links=f"""<link type="image/jpeg" href="/opds/book/{book_id}/cover" rel="http://opds-spec.org/image"/>""",
             )
         )
     return items

--- a/src/opds_server/services/opds.py
+++ b/src/opds_server/services/opds.py
@@ -146,18 +146,18 @@ def generate_title_feed(endpoint: str, page: int) -> str:
     return generate_feed(feed)
 
 
-def items_from_books(books: list[dict]) -> list[Item]:
+def items_from_books(books: dict[int, dict]) -> list[Item]:
     items = []
-    for book in books:
+    for book_id, book in books.items():
         items.append(
             Item(
                 title=book["title"],
-                id=generate_book_id(book["title"]),
+                id=generate_book_id(str(book_id)),
                 updated_time=book["last_modified"],
                 author=book["authors"][0],
                 links=f"""
-            <link type="application/pdf" href="/opds/book/{book["id"]}/file" rel="http://opds-spec.org/acquisition"/>
-            <link type="image/jpeg" href="/opds/book/{book["id"]}/cover" rel="http://opds-spec.org/image"/>
+            <link type="application/pdf" href="/opds/book/{book_id}/file" rel="http://opds-spec.org/acquisition"/>
+            <link type="image/jpeg" href="/opds/book/{book_id}/cover" rel="http://opds-spec.org/image"/>
             """,
             )
         )


### PR DESCRIPTION
## What

Add support for multi-format book downloads with correct MIME types and improved filename generation in the OPDS server.

## Why

Previously:
- The API only returned a single book file with a generic `application/{ext}` MIME type.
- OPDS feeds contained a single acquisition link without format differentiation.
- `title_to_filename()` could generate invalid filenames (empty, trailing dots/spaces).

This limited compatibility with OPDS clients and caused unreliable file downloads.

## How

- Replaced `get_book_path()` with `get_book_file_path(book_id, format)` for format-specific file resolution.
- Added `add_files()` to enrich book metadata with available formats.
- Changed book collections from `list[dict]` to `dict[int, dict]` keyed by book ID.
- Introduced `MIME_BY_EXT` and `get_book_mime_type()` to return correct `Content-Type` headers.
- Updated OPDS feeds to generate acquisition links for all available formats with proper MIME types.
- Enhanced `title_to_filename()` sanitization:
- Strip trailing spaces/dots.
- Fallback to "book" if empty.
- Generate filenames as `{title}.{extension}`.