### PR TITLE
feat: add OPDS feeds for browsing by author

### DIFF
--- a/src/opds_server/api/catalog.py
+++ b/src/opds_server/api/catalog.py
@@ -7,6 +7,7 @@ from opds_server.services.opds import (
     generate_newest_feed,
     generate_title_feed,
     generate_book_search_feed,
+    generate_author_feed,
     get_book_mime_type,
 )
 from opds_server.db.access import get_book_file_path, get_cover_path, get_book_title
@@ -83,4 +84,10 @@ def root_by_newest(page: int = Query(1, ge=1)):
 @router.get("/opds/by-title", response_class=Response)
 def root_by_title(page: int = Query(1, ge=1)):
     xml = generate_title_feed("/opds/by-title", page)
+    return Response(content=xml, media_type="application/atom+xml; charset=utf-8")
+
+
+@router.get("/opds/author/{author_id}")
+def get_author_books(author_id: int, page: int = Query(1, ge=1)):
+    xml = generate_author_feed(f"/opds/author/{author_id}", author_id, page)
     return Response(content=xml, media_type="application/atom+xml; charset=utf-8")

--- a/src/opds_server/api/catalog.py
+++ b/src/opds_server/api/catalog.py
@@ -7,6 +7,7 @@ from opds_server.services.opds import (
     generate_newest_feed,
     generate_title_feed,
     generate_book_search_feed,
+    generate_by_author_feed,
     generate_author_feed,
     get_book_mime_type,
 )
@@ -84,6 +85,12 @@ def root_by_newest(page: int = Query(1, ge=1)):
 @router.get("/opds/by-title", response_class=Response)
 def root_by_title(page: int = Query(1, ge=1)):
     xml = generate_title_feed("/opds/by-title", page)
+    return Response(content=xml, media_type="application/atom+xml; charset=utf-8")
+
+
+@router.get("/opds/by-author")
+def root_by_author(page: int = Query(1, ge=1)):
+    xml = generate_by_author_feed("/opds/by-author", page)
     return Response(content=xml, media_type="application/atom+xml; charset=utf-8")
 
 

--- a/src/opds_server/db/access.py
+++ b/src/opds_server/db/access.py
@@ -81,6 +81,16 @@ def get_cover_path(book_id: int) -> Path:
         return cover
 
 
+def get_author_name(author_id: int) -> str:
+    with connect_db() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM authors WHERE id=?", (author_id,))
+        row = cursor.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Author not found")
+        return row[0]
+
+
 def add_authors(books: list) -> dict[int, dict]:
     book_ids = [book[0] for book in books]
     with connect_db() as conn:

--- a/src/opds_server/db/access.py
+++ b/src/opds_server/db/access.py
@@ -181,6 +181,20 @@ def get_books(
     return select_books(sql, page, limit)
 
 
+def get_author_books(
+    author_id: int, page: int, limit: int = 10
+) -> tuple[dict[int, dict], bool, bool]:
+    sql = """
+          SELECT b.id, b.title, b.last_modified
+          FROM books b
+          JOIN books_authors_link bal ON b.id = bal.book
+          WHERE bal.author = ?
+          ORDER BY b.sort
+          """
+
+    return select_books(sql, page, limit, [author_id])
+
+
 def search_books(
     query: str, page: int, limit: int = 10
 ) -> tuple[dict[int, dict], bool, bool]:

--- a/src/opds_server/db/access.py
+++ b/src/opds_server/db/access.py
@@ -191,6 +191,26 @@ def get_books(
     return select_books(sql, page, limit)
 
 
+def get_authors(page: int, limit: int = 10) -> tuple[list, bool, bool]:
+    sql = """
+          SELECT id, name
+          FROM authors
+          ORDER BY sort
+          """
+
+    with connect_db() as conn:
+        cur = conn.cursor()
+        offset = (page - 1) * limit
+        sql += "LIMIT ? OFFSET ?"
+        cur.execute(sql, [limit + 1, offset])
+        authors = cur.fetchall()
+
+        has_next = len(authors) > limit
+        has_previous = offset > 0
+
+        return authors, has_previous, has_next
+
+
 def get_author_books(
     author_id: int, page: int, limit: int = 10
 ) -> tuple[dict[int, dict], bool, bool]:

--- a/src/opds_server/services/opds.py
+++ b/src/opds_server/services/opds.py
@@ -227,7 +227,7 @@ def generate_by_author_feed(param, page):
         entries += f"""
         <entry>
             <title>{author[1]}</title>
-            <id>{author[0]}</id>
+            <id>urn:opds-server:author:{author[0]}</id>,
             <author>
                 <name>Calibre OPDS Server</name>
             </author>
@@ -239,7 +239,7 @@ def generate_by_author_feed(param, page):
     feed = f"""<?xml version="1.0" encoding="utf-8"?>
     <feed xmlns="http://www.w3.org/2005/Atom">
         <title>By Authors</title>
-        <id>urn:opds-server:by-title</id>
+        <id>urn:opds-server:by-author</id>
         <updated>{datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")}</updated>
         <author>
             <name>Calibre OPDS Server</name>

--- a/src/opds_server/services/opds.py
+++ b/src/opds_server/services/opds.py
@@ -1,4 +1,9 @@
-from opds_server.db.access import get_books, search_books, get_author_books
+from opds_server.db.access import (
+    get_books,
+    search_books,
+    get_author_books,
+    get_author_name,
+)
 from datetime import datetime, timezone
 
 from opds_server.db.access import generate_book_id
@@ -213,8 +218,10 @@ def generate_author_feed(
 
     items = items_from_books(books)
 
+    author_name = get_author_name(author_id)
+
     feed = Feed(
-        title=f"Books by Author ID {author_id}",
+        title=f"Books by {author_name}",
         id=f"urn:opds-server:author:{author_id}",
         updated_time=datetime.now(timezone.utc),
         items=items,

--- a/src/opds_server/services/opds.py
+++ b/src/opds_server/services/opds.py
@@ -63,7 +63,7 @@ def get_author_xml(author: dict) -> str:
         return f"""
             <author>
                 <name>{author["name"]}</name>
-                <uri>/opds/author</uri>
+                <uri>/opds/author/{author["id"]}</uri>
             </author>
         """
     else:

--- a/src/opds_server/services/opds.py
+++ b/src/opds_server/services/opds.py
@@ -1,4 +1,4 @@
-from opds_server.db.access import get_books, search_books
+from opds_server.db.access import get_books, search_books, get_author_books
 from datetime import datetime, timezone
 
 from opds_server.db.access import generate_book_id
@@ -63,6 +63,7 @@ def get_author_xml(author: dict) -> str:
         return f"""
             <author>
                 <name>{author["name"]}</name>
+                <uri>/opds/author</uri>
             </author>
         """
     else:
@@ -202,6 +203,26 @@ def generate_title_feed(endpoint: str, page: int) -> str:
         previous=has_previous,
     )
 
+    return generate_feed(feed)
+
+
+def generate_author_feed(
+    endpoint: str, author_id: int, page: int = 1, limit: int = 10
+) -> str:
+    books, has_previous, has_next = get_author_books(author_id, page=page)
+
+    items = items_from_books(books)
+
+    feed = Feed(
+        title=f"Books by Author ID {author_id}",
+        id=f"urn:opds-server:author:{author_id}",
+        updated_time=datetime.now(timezone.utc),
+        items=items,
+        endpoint=endpoint,
+        page=page,
+        next=has_next,
+        previous=has_previous,
+    )
     return generate_feed(feed)
 
 


### PR DESCRIPTION
# What  
- Add support for browsing books by author.  

# Why  
- Browsing by author is part of the common OPDS navigation structure and provides users with a familiar way to explore books.  

# How  
- Add a new endpoint: `/opds/by-author` to serve a paginated list of authors.  
- Add a new endpoint: `/opds/author/{author_id}` to serve a paginated list of books by a specific author.  
- Insert a "By Author" Item into the root feed with proper OPDS `rel="sort"` metadata.  
- Extend the database layer with:  
  - `get_authors(page, limit)` → fetch authors with pagination.  
  - `get_author_books(author_id, page, limit)` → fetch books linked to an author.  
  - `get_author_name(author_id)` → fetch the author’s name or return 404 if not found.  
- Implement `generate_by_author_feed()` to produce an Atom feed of authors.  
- Implement `generate_author_feed()` to produce an Atom feed of books filtered by author.  
- Update `<author>` XML to include `<uri>/opds/author/{id}</uri>`.  