### PR TITLE
chore(ci): add concurrency to cancel in-progress builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -54,7 +57,6 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          # platforms: linux/amd64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
# What
Add a concurrency group to the Docker CI workflow so that only the latest run
per branch, tag or PR is executed

# Why
Without concurrency, multiple pushes in quick succession can trigger parallel
builds. Older builds may finish later and overwrite tags (e.g. ), or
consume unnecessary runner minutes

# How
- Define a concurrency group as 
and enable . This ensures that only the most recent
workflow run for the same branch/tag/PR continues, while previous runs are
automatically cancelled