### PR TITLE
test: add database-backed endpoint suite

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -103,6 +103,110 @@ files = [
 markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
+name = "coverage"
+version = "7.15.2"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "coverage-7.15.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b5bd92ff1ec22e535eab0de75fa6db021992791f461a2aceb7822c625a1187d"},
+    {file = "coverage-7.15.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44826758cfe73fcd0e6af5deb4ba6d5417cc1d13df3acb35c93484a11160f846"},
+    {file = "coverage-7.15.2-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:09f5c6ec5901f667bd97dd140b5b9a2586b10efec66f46fb1e6d8135f8b95bdf"},
+    {file = "coverage-7.15.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1d16e3a7104ea84f03e614611b3edbf6fb6892554b3ab0fe7fbb3f2b2ef04376"},
+    {file = "coverage-7.15.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d46e62cb35d91e6e2589fda6d28074426b0e276422b5d2ebef2c6b11dc60dbfd"},
+    {file = "coverage-7.15.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dfd3db045e95960ae3683059571e597fda7cc610106a8916f77c5839048c1deb"},
+    {file = "coverage-7.15.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:affd532502d34c0472d0cdb181325c89f1d2c44992fef0c17e88e7b1576259a1"},
+    {file = "coverage-7.15.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d17d7512151fedfcc64c1821a8977fc9be0dbf495754669afcab7b57abc98ae9"},
+    {file = "coverage-7.15.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e26ff680768b8095e8874aabe0e9d3a47a2a9f176a8340d05f8604c56457c23a"},
+    {file = "coverage-7.15.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7e8f27131dc7cd53de2c137dd207b3720919320b3c20d499dc30aa9ee6173287"},
+    {file = "coverage-7.15.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:728a33676d4c3f0db977990a4bd421dcaa3be3e53b5b6273036fff6666008e89"},
+    {file = "coverage-7.15.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:29c052f7c83ccfcc5c577eaae025d2e4a9bb80daf03c0ac31c996e83b000ce88"},
+    {file = "coverage-7.15.2-cp310-cp310-win32.whl", hash = "sha256:1268ac8fb9ddcd783d3948dbabaf80a5d53bfdaa0575e873e2139a692f797443"},
+    {file = "coverage-7.15.2-cp310-cp310-win_amd64.whl", hash = "sha256:9f4432898c4bf2fba0435bbe35dd4437d7264565e5a88a21f5b49d8662a6b629"},
+    {file = "coverage-7.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036"},
+    {file = "coverage-7.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660"},
+    {file = "coverage-7.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589"},
+    {file = "coverage-7.15.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d50dd325e18ec25bfcc10cd7f99b04df1ab9ec76b0918c260e60817ad0643dee"},
+    {file = "coverage-7.15.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67d7602480a47bdf5b675635403625553ebaa70d5a62a657c035149fd401cea0"},
+    {file = "coverage-7.15.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cee0f89f4767a6057c8fbf168f8135f18be651300496086bd873e3189fed0487"},
+    {file = "coverage-7.15.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a29ec5305a7335aacee2d799e3422e91e1c8a12474986e2b3b07e315c91be82f"},
+    {file = "coverage-7.15.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:48ccc6395958eda89093ecdc35644c86f23a8b23a7f4d44958812b721aad67c1"},
+    {file = "coverage-7.15.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:81f382c5a94b434ec1f6da607edb904c76d7212e618cd4d1bc9f97bed4120ef5"},
+    {file = "coverage-7.15.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bbc808daf4f5cd567af8075ecc72d21c6dfef9a254709a621a84c217c935ebc0"},
+    {file = "coverage-7.15.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a4c46b247b5d4b78f613bd89fea926d32b25c6cc61a50bd1e99ba310348f3dad"},
+    {file = "coverage-7.15.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:094dd37f3ef7b2da8b068b583d1f4c40f91c65197e16c52a71962d5d537fc5db"},
+    {file = "coverage-7.15.2-cp311-cp311-win32.whl", hash = "sha256:a63b9e190711134d581c4d703df5df09851b1acf99792c7aacbbe9f41f0283c9"},
+    {file = "coverage-7.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:8bb9f4b4279187560796a4cdaca3b0a93dd97e48ee667df005f4ed9a97403688"},
+    {file = "coverage-7.15.2-cp311-cp311-win_arm64.whl", hash = "sha256:8c726b232659cbd2ae57ade46509eb068c9bd7a06df9fcbff6fe484870006934"},
+    {file = "coverage-7.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1adac78e5abc7c5438f7a209c9ca69d06542f0bf481d728b6989ea80b813fdf9"},
+    {file = "coverage-7.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b868acc62aa5de3be7a9d05c2333bf8359ca987e43f9cb30ff8fbda6a024ab73"},
+    {file = "coverage-7.15.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6f6966fc30e6f06ca8f98fb0ce51eda6b111b3ee8d066a8b1ec9e77fa06ab55d"},
+    {file = "coverage-7.15.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:68af907f595ab01a78f794932ff3bdf929c316d3000810d38dbc247129e26f8b"},
+    {file = "coverage-7.15.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afa29e2eff3d5729267e2cb2fd4ce9d61c952932fb2694e34ccb5d9540c6a296"},
+    {file = "coverage-7.15.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbf44513ceb1589e31948e20eafbde9deaface90e1a1afa5f5f77b4423d17ce6"},
+    {file = "coverage-7.15.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9deddf09eecb717b7f980414b43d90a5b22ff3967d2949ab29cb0aa83d9e9098"},
+    {file = "coverage-7.15.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ae901f7e55ba405c84ee1cab3d3e962e4e871e4a2bcb9c90911adbd69b42ac5a"},
+    {file = "coverage-7.15.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a0f47002c6eeb7c280228467a4cb0cc15ca2103a8421b986b2d3ec04a0f9bd8b"},
+    {file = "coverage-7.15.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd7a5beb7af3e864a13b1f0fb26efd3695da43ef0daf71e586adfffaf34d5b2"},
+    {file = "coverage-7.15.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97a5c5457a9fb1d6c4e06cfb5dc835871fbfb6a6a51addc9e925bdeff5ef7440"},
+    {file = "coverage-7.15.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0901cfe6c13bcd2302da4f83e884555d2a22bda6e4c476f09ef204ba20ca536e"},
+    {file = "coverage-7.15.2-cp312-cp312-win32.whl", hash = "sha256:b171bdd71cb7ff792bf32e376173b0ace7e7963e7e57c58dfc42063a6a7174cd"},
+    {file = "coverage-7.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:582edc45c2040543fef83341be23c43024a3ab3ae0c2d8bc498a06282905ad40"},
+    {file = "coverage-7.15.2-cp312-cp312-win_arm64.whl", hash = "sha256:a638db90c61cd219aeee65e83a24fdaa57269a741ae0cf773309208ac862cee3"},
+    {file = "coverage-7.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8"},
+    {file = "coverage-7.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1"},
+    {file = "coverage-7.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578"},
+    {file = "coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1"},
+    {file = "coverage-7.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6"},
+    {file = "coverage-7.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7"},
+    {file = "coverage-7.15.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d"},
+    {file = "coverage-7.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026"},
+    {file = "coverage-7.15.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa"},
+    {file = "coverage-7.15.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d"},
+    {file = "coverage-7.15.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b"},
+    {file = "coverage-7.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188"},
+    {file = "coverage-7.15.2-cp313-cp313-win32.whl", hash = "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050"},
+    {file = "coverage-7.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c"},
+    {file = "coverage-7.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b"},
+    {file = "coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a"},
+    {file = "coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2"},
+    {file = "coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138"},
+    {file = "coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f"},
+    {file = "coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984"},
+    {file = "coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7"},
+    {file = "coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3"},
+    {file = "coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee"},
+    {file = "coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1"},
+    {file = "coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a"},
+    {file = "coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145"},
+    {file = "coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446"},
+    {file = "coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243"},
+    {file = "coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc"},
+    {file = "coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635"},
+    {file = "coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be"},
+    {file = "coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072"},
+    {file = "coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328"},
+    {file = "coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a"},
+    {file = "coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0"},
+    {file = "coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5"},
+    {file = "coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743"},
+    {file = "coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c"},
+    {file = "coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071"},
+    {file = "coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a"},
+    {file = "coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d"},
+    {file = "coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c"},
+    {file = "coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688"},
+    {file = "coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199"},
+    {file = "coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658"},
+    {file = "coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c"},
+    {file = "coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d"},
+]
+
+[package.extras]
+toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
+
+[[package]]
 name = "detect-installer"
 version = "0.1.0"
 description = "Detect how a Python package was installed and get the correct upgrade command"
@@ -926,6 +1030,26 @@ pygments = ">=2.7.2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "6.3.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749"},
+    {file = "pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2"},
+]
+
+[package.dependencies]
+coverage = {version = ">=7.5", extras = ["toml"]}
+pluggy = ">=1.2"
+pytest = ">=6.2.5"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1678,4 +1802,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "2cfbc5597c46f2815c648a34a44e7472eb8cb54b52ddfe39d27442b3dfdb6266"
+content-hash = "a32f86d94c5c001a1171a2381c55d909763dbe92181492fced4ba670a9b466ad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ packages = [{include = "opds_server", from = "src"}]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"
+pytest-cov = "^6.2.1"
+
+[tool.pytest.ini_options]
+addopts = "--cov=opds_server --cov-report=term-missing --cov-fail-under=85"
+testpaths = ["tests"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/src/opds_server/services/opds.py
+++ b/src/opds_server/services/opds.py
@@ -323,6 +323,7 @@ async def generate_author_feed(
 
 
 def items_from_books(books: dict[int, dict]) -> list[Item]:
+    """Convert database records to entries, including incomplete metadata."""
     items = []
     for book_id, book in books.items():
         items.append(
@@ -331,7 +332,8 @@ def items_from_books(books: dict[int, dict]) -> list[Item]:
                 id=generate_book_id(str(book_id)),
                 db_id=book_id,
                 updated_time=book["last_modified"],
-                author=book["authors"][0],
+                # Calibre libraries can contain books without an author link.
+                author=book["authors"][0] if book["authors"] else {},
                 files=book["files"],
                 links=f"""<link type="image/jpeg" href="/opds/book/{book_id}/cover" rel="http://opds-spec.org/image"/>""",
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,111 @@
+"""Shared database-backed fixtures for OPDS endpoint integration tests."""
+
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from opds_server.core.config import Config, get_config
+from opds_server.main import create_app
+
+CALIBRE_SCHEMA = """
+CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT NOT NULL, sort TEXT NOT NULL, last_modified TEXT, path TEXT NOT NULL);
+CREATE TABLE authors (id INTEGER PRIMARY KEY, name TEXT NOT NULL, sort TEXT NOT NULL);
+CREATE TABLE books_authors_link (book INTEGER NOT NULL, author INTEGER NOT NULL);
+CREATE TABLE data (book INTEGER NOT NULL, format TEXT NOT NULL, name TEXT NOT NULL);
+"""
+
+
+def _populate_library(connection: sqlite3.Connection, library: Path) -> None:
+    """Populate a compact catalog containing pagination and escaping edge
+    cases."""
+    connection.executemany(
+        "INSERT INTO authors VALUES (?, ?, ?)",
+        [(1, "Ada & Sons", "Ada & Sons"), (2, "Zoë Автор", "Zoe Author")],
+    )
+    connection.executemany(
+        "INSERT INTO books VALUES (?, ?, ?, ?, ?)",
+        [
+            (
+                1,
+                "A <Practical> Book",
+                "A Practical Book",
+                "2024-01-04 12:00:00+00:00",
+                "Ada/Practical",
+            ),
+            (
+                2,
+                "100% Unicode книга",
+                "100 Unicode",
+                "2024-01-03 12:00:00+00:00",
+                "Zoe/Unicode",
+            ),
+            (
+                3,
+                "Under_score",
+                "Under score",
+                "2024-01-02 12:00:00+00:00",
+                "Shared/Under",
+            ),
+            (
+                4,
+                "Authorless",
+                "Authorless",
+                "2024-01-01 12:00:00+00:00",
+                "Nobody/Authorless",
+            ),
+        ],
+    )
+    connection.executemany(
+        "INSERT INTO books_authors_link VALUES (?, ?)",
+        [(1, 1), (1, 2), (2, 2), (3, 1)],
+    )
+    connection.executemany(
+        "INSERT INTO data VALUES (?, ?, ?)",
+        [(1, "EPUB", "Practical"), (1, "PDF", "Practical"), (2, "EPUB", "Unicode")],
+    )
+    for relative_path, contents in {
+        "Ada/Practical/Practical.epub": b"epub contents",
+        "Ada/Practical/Practical.pdf": b"pdf contents",
+        "Ada/Practical/cover.jpg": b"jpeg contents",
+        "Zoe/Unicode/Unicode.epub": b"unicode contents",
+    }.items():
+        target = library / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(contents)
+
+
+@pytest.fixture
+def client_factory(tmp_path: Path) -> Callable[..., tuple[Path, TestClient]]:
+    """Build isolated apps backed by a minimal read-only Calibre-style
+    database."""
+    sequence = 0
+
+    def make_client(
+        *, populated: bool = True, page_size: int = 2
+    ) -> tuple[Path, TestClient]:
+        nonlocal sequence
+        sequence += 1
+        library = tmp_path / f"library-{sequence}"
+        library.mkdir()
+        connection = sqlite3.connect(library / "metadata.db")
+        connection.executescript(CALIBRE_SCHEMA)
+        if populated:
+            _populate_library(connection, library)
+        connection.commit()
+        connection.close()
+
+        config = Config(calibre_library_path=library, page_size=page_size)
+        app = create_app(config)
+        app.dependency_overrides[get_config] = lambda: config
+        return library, TestClient(app, raise_server_exceptions=False)
+
+    return make_client
+
+
+@pytest.fixture
+def catalog_client(client_factory) -> tuple[Path, TestClient]:
+    """Return the standard populated library and its isolated test client."""
+    return client_factory()

--- a/tests/test_catalog_endpoints.py
+++ b/tests/test_catalog_endpoints.py
@@ -1,0 +1,193 @@
+"""Database-backed integration tests for the public OPDS and service
+endpoints."""
+
+from datetime import datetime
+from urllib.parse import parse_qs, urlsplit
+from xml.etree import ElementTree
+
+import pytest
+
+ATOM = "http://www.w3.org/2005/Atom"
+OPENSEARCH = "http://a9.com/-/spec/opensearch/1.1/"
+NS = {"atom": ATOM, "os": OPENSEARCH}
+
+
+def parse_atom(response) -> ElementTree.Element:
+    """Assert the OPDS media type and parse a structurally valid Atom feed."""
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/atom+xml")
+    root = ElementTree.fromstring(response.content)
+    assert root.tag == f"{{{ATOM}}}feed"
+    return root
+
+
+def entries(feed: ElementTree.Element) -> list[ElementTree.Element]:
+    """Return Atom entries from a parsed feed."""
+    return feed.findall("atom:entry", NS)
+
+
+def links(element: ElementTree.Element, rel: str) -> list[ElementTree.Element]:
+    """Return direct Atom links having the requested relation."""
+    return [link for link in element.findall("atom:link", NS) if link.get("rel") == rel]
+
+
+def test_root_navigation_is_valid_atom(catalog_client):
+    """Expose namespaced navigation entries with stable IDs and usable
+    links."""
+    _, client = catalog_client
+    feed = parse_atom(client.get("/opds"))
+    assert feed.findtext("atom:id", namespaces=NS) == "urn:opds-server:main"
+    assert [entry.findtext("atom:title", namespaces=NS) for entry in entries(feed)] == [
+        "By Newest",
+        "By Title",
+        "By Author",
+    ]
+    for entry in entries(feed):
+        assert client.get(entry.find("atom:link", NS).get("href")).status_code == 200
+
+
+@pytest.mark.parametrize("endpoint", ["/opds/by-title", "/opds/by-newest"])
+def test_book_feeds_include_metadata_and_valid_acquisition_links(
+    catalog_client, endpoint
+):
+    """Serialize escaped metadata, timestamps, covers, and downloadable
+    formats."""
+    _, client = catalog_client
+    first = entries(parse_atom(client.get(endpoint)))[0]
+    assert first.findtext("atom:id", namespaces=NS).startswith("calibre-navcatalog:")
+    datetime.fromisoformat(
+        first.findtext("atom:updated", namespaces=NS).replace("Z", "+00:00")
+    )
+    for link in first.findall("atom:link", NS):
+        href = link.get("href")
+        assert href.startswith("/opds/")
+        if link.get("rel") == "http://opds-spec.org/acquisition":
+            assert client.get(href).status_code == 200
+
+
+def test_title_feed_paginates_at_boundaries(catalog_client):
+    """Publish correct previous and next relations at each page boundary."""
+    _, client = catalog_client
+    first = parse_atom(client.get("/opds/by-title?page=1"))
+    second = parse_atom(client.get("/opds/by-title?page=2"))
+    beyond = parse_atom(client.get("/opds/by-title?page=3"))
+    assert len(entries(first)) == 2
+    assert not links(first, "previous") and links(first, "next")
+    assert len(entries(second)) == 2
+    assert links(second, "previous") and not links(second, "next")
+    assert not entries(beyond)
+    assert links(beyond, "previous") and not links(beyond, "next")
+
+
+def test_author_navigation_detail_and_authorless_books(catalog_client):
+    """Follow author links and keep authorless or multiply-authored books
+    readable."""
+    _, client = catalog_client
+    author_feed = parse_atom(client.get("/opds/by-author"))
+    detail_href = entries(author_feed)[0].find("atom:link", NS).get("href")
+    detail = parse_atom(client.get(detail_href))
+    assert detail.findtext("atom:title", namespaces=NS) == "Books by Ada & Sons"
+    assert {
+        entry.findtext("atom:title", namespaces=NS) for entry in entries(detail)
+    } == {
+        "A <Practical> Book",
+        "Under_score",
+    }
+    second_page = parse_atom(client.get("/opds/by-title?page=2"))
+    assert "Authorless" in {
+        entry.findtext("atom:title", namespaces=NS) for entry in entries(second_page)
+    }
+
+
+@pytest.mark.parametrize(
+    ("query", "page", "expected_title"),
+    [
+        ("Unicode книга", 1, "100% Unicode книга"),
+        ("<Practical>", 1, "A <Practical> Book"),
+        ("%", 1, "100% Unicode книга"),
+        ("_", 2, "Under_score"),
+    ],
+)
+def test_search_special_queries(catalog_client, query, page, expected_title):
+    """Keep Unicode, XML-special, and SQL wildcard queries valid in XML and
+    URLs."""
+    _, client = catalog_client
+    feed = parse_atom(client.get("/opds/search", params={"q": query, "page": page}))
+    titles = {entry.findtext("atom:title", namespaces=NS) for entry in entries(feed)}
+    assert expected_title in titles
+    assert parse_qs(urlsplit(links(feed, "self")[0].get("href")).query)["q"] == [query]
+
+
+def test_empty_catalog_returns_valid_empty_feeds(client_factory):
+    """Return well-formed feeds without entries for a valid empty database."""
+    _, client = client_factory(populated=False)
+    for endpoint in ("/opds/by-title", "/opds/by-newest", "/opds/by-author"):
+        assert not entries(parse_atom(client.get(endpoint)))
+
+
+def test_download_and_cover_responses(catalog_client):
+    """Serve known files with correct types and stable not-found responses."""
+    _, client = catalog_client
+    book = client.get("/opds/book/1/file/epub")
+    cover = client.get("/opds/book/1/cover")
+    assert (book.status_code, book.content, book.headers["content-type"]) == (
+        200,
+        b"epub contents",
+        "application/epub+zip",
+    )
+    assert (cover.status_code, cover.content, cover.headers["content-type"]) == (
+        200,
+        b"jpeg contents",
+        "image/jpeg",
+    )
+    assert client.get("/opds/book/3/file/epub").text == "Book file not found"
+    assert client.get("/opds/book/2/cover").text == "Cover not found"
+    assert client.get("/opds/book/999/file/epub").status_code == 404
+
+
+def test_service_endpoints_and_root_redirect(catalog_client):
+    """Expose liveness, readiness, and a root redirect to the configured
+    catalog."""
+    _, client = catalog_client
+    assert client.get("/healthz").text == "ok"
+    assert client.get("/ready").text == "ok"
+    redirect = client.get("/", follow_redirects=False)
+    assert (redirect.status_code, redirect.headers["location"]) == (307, "/opds")
+
+
+def test_readiness_fails_safely_after_database_disappears(catalog_client):
+    """Avoid exposing filesystem details when metadata.db vanishes at
+    runtime."""
+    library, client = catalog_client
+    (library / "metadata.db").unlink()
+    response = client.get("/ready")
+    assert (response.status_code, response.text) == (500, "Calibre DB not found")
+    assert str(library) not in response.text
+
+
+def test_opensearch_document_is_namespaced(catalog_client):
+    """Advertise search through a parseable, namespaced OpenSearch document."""
+    _, client = catalog_client
+    response = client.get("/opds/opensearch.xml")
+    root = ElementTree.fromstring(response.content)
+    assert response.status_code == 200
+    assert root.tag == f"{{{OPENSEARCH}}}OpenSearchDescription"
+    assert root.find("os:Url", NS).get("template") == "/opds/search?q={searchTerms}"
+
+
+@pytest.mark.parametrize(
+    ("path", "status", "message"),
+    [
+        ("/opds/by-title?page=0", 422, None),
+        ("/opds/author/999", 404, "Author not found"),
+        ("/opds/book/999/cover", 404, "Cover not found"),
+    ],
+)
+def test_error_responses_are_stable(catalog_client, path, status, message):
+    """Return deliberate client errors for invalid pages and missing
+    resources."""
+    _, client = catalog_client
+    response = client.get(path)
+    assert response.status_code == status
+    if message:
+        assert response.text == message


### PR DESCRIPTION
- exercise OPDS feeds, search, pagination, files, probes, and errors
- enforce an initial 85 percent coverage threshold
- keep authorless books from crashing catalog feeds
