### PR TITLE
fix(config): validate startup readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ The server can be configured using environment variables
 
 | Variable | Default | Description |
 |---|---|---|
-| `PAGE_SIZE` | `30` | Number of books or authors shown on each OPDS feed page. |
+| `CALIBRE_LIBRARY_PATH` | `/books` | Absolute path to the mounted Calibre library. |
+| `PAGE_SIZE` | `30` | Number of books or authors shown on each OPDS feed page, from 1 through 100. |
 | `OPDS_PREFIX` | `/opds` | URL path where the catalog is mounted. A leading slash is optional; trailing slashes are removed. |
+
+The server starts when the configured library is temporarily unavailable so
+that `/healthz` can continue to report process liveness. `/ready` checks the
+library on every request and returns `503 Calibre database unavailable` until
+`metadata.db` can be accessed.
 
 ## Installation / Run
 

--- a/src/opds_server/core/config.py
+++ b/src/opds_server/core/config.py
@@ -1,16 +1,27 @@
 from functools import lru_cache
 from pathlib import Path
+from typing import Annotated
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 
 class Config(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
     app_name: str = "OPDS Server"
     package_name: str = "opds-server"
     calibre_library_path: Path = "/books"
     opds_prefix: str = "/opds"
-    page_size: int = 30
+    page_size: Annotated[int, Field(ge=1, le=100)] = 30
+
+    @field_validator("calibre_library_path")
+    @classmethod
+    def validate_calibre_library_path(cls, value: Path) -> Path:
+        """Require an unambiguous path without requiring a mounted library."""
+        if not value.is_absolute():
+            raise ValueError("CALIBRE_LIBRARY_PATH must be an absolute path")
+        return value
 
     @field_validator("opds_prefix", mode="before")
     @classmethod

--- a/src/opds_server/db/access.py
+++ b/src/opds_server/db/access.py
@@ -73,6 +73,7 @@ def get_db_uri(config: Config) -> str:
 
 @asynccontextmanager
 async def connect_db(config: Config) -> AsyncIterator[aiosqlite.Connection]:
+    """Open the configured Calibre database read-only."""
     try:
         conn = await aiosqlite.connect(
             get_db_uri(config),
@@ -89,6 +90,12 @@ async def connect_db(config: Config) -> AsyncIterator[aiosqlite.Connection]:
         raise HTTPException(
             status_code=503, detail="Calibre database unavailable"
         ) from None
+
+
+async def check_library_availability(config: Config) -> None:
+    """Verify that the configured Calibre database can answer a query."""
+    async with connect_db(config) as conn:
+        await conn.execute("SELECT 1")
 
 
 async def get_book_title(book_id: int, config: Config) -> str:

--- a/src/opds_server/main.py
+++ b/src/opds_server/main.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from importlib.metadata import PackageNotFoundError, version
 
 from fastapi import FastAPI, HTTPException
@@ -6,9 +8,7 @@ from starlette.responses import PlainTextResponse, RedirectResponse
 
 from opds_server.api import catalog
 from opds_server.core.config import Config, get_config
-from opds_server.db.access import connect_db
-
-config = Config()
+from opds_server.db.access import check_library_availability
 
 
 def _get_version(pkg: str) -> str:
@@ -19,23 +19,47 @@ def _get_version(pkg: str) -> str:
 
 
 def create_app(config: Config | None = None) -> FastAPI:
-    config = config or get_config()
+    """Create an application using one consistent configuration instance."""
+    app_config = config or get_config()
+    log = logging.getLogger("uvicorn.error")
 
-    # Get application version
-    package_version = _get_version(config.package_name)
+    @asynccontextmanager
+    async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+        """Check initial readiness without making library access liveness."""
+        try:
+            await check_library_availability(app_config)
+        except HTTPException as exc:
+            if exc.status_code != 503:
+                raise
+            log.warning("Starting with Calibre database unavailable")
+        yield
 
-    app = FastAPI(title=config.app_name, version=package_version)
+    package_version = _get_version(app_config.package_name)
+    app = FastAPI(
+        title=app_config.app_name,
+        version=package_version,
+        lifespan=lifespan,
+    )
+
+    if config is not None:
+
+        def get_supplied_config() -> Config:
+            """Provide the configuration supplied to the application
+            factory."""
+            return app_config
+
+        app.dependency_overrides[get_config] = get_supplied_config
 
     # FastAPI represents a root-mounted router with an empty prefix.
-    router_prefix = "" if config.opds_prefix == "/" else config.opds_prefix
+    router_prefix = "" if app_config.opds_prefix == "/" else app_config.opds_prefix
     app.include_router(catalog.router, prefix=router_prefix, tags=["opds"])
 
-    if config.opds_prefix != "/":
+    if app_config.opds_prefix != "/":
 
         @app.get("/", include_in_schema=False)
         def root_redirect():
             """Redirect root URL to the configured OPDS feed."""
-            return RedirectResponse(url=config.opds_prefix, status_code=307)
+            return RedirectResponse(url=app_config.opds_prefix, status_code=307)
 
     @app.get("/healthz", tags=["_service"], include_in_schema=False)
     def healthz() -> PlainTextResponse:
@@ -45,12 +69,8 @@ def create_app(config: Config | None = None) -> FastAPI:
     @app.get("/ready", tags=["_service"], include_in_schema=False)
     async def ready() -> PlainTextResponse:
         """Readiness probe endpoint."""
-        async with connect_db(config) as conn:
-            await conn.execute("SELECT 1")
+        await check_library_availability(app_config)
         return PlainTextResponse("ok")
-
-    # Set up logging
-    log = logging.getLogger("uvicorn.error")
 
     @app.exception_handler(HTTPException)
     def http_exception_handler(_, exc: HTTPException):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from opds_server.core.config import Config, get_config
+from opds_server.core.config import Config
 from opds_server.main import create_app
 
 CALIBRE_SCHEMA = """
@@ -106,7 +106,6 @@ def client_factory(tmp_path: Path) -> Callable[..., tuple[Path, TestClient]]:
             opds_prefix=opds_prefix,
         )
         app = create_app(config)
-        app.dependency_overrides[get_config] = lambda: config
         return library, TestClient(app, raise_server_exceptions=False)
 
     return make_client

--- a/tests/test_catalog_endpoints.py
+++ b/tests/test_catalog_endpoints.py
@@ -191,6 +191,16 @@ def test_service_endpoints_and_root_redirect(catalog_client):
     assert (redirect.status_code, redirect.headers["location"]) == (307, "/opds")
 
 
+def test_available_library_passes_startup_check(catalog_client, caplog):
+    """Start normally when the configured library is already available."""
+    _, client = catalog_client
+    with client:
+        response = client.get("/ready")
+
+    assert (response.status_code, response.text) == (200, "ok")
+    assert "Starting with Calibre database unavailable" not in caplog.text
+
+
 @pytest.mark.parametrize("endpoint", ["/ready", "/opds/by-title"])
 def test_requests_fail_safely_after_database_disappears(catalog_client, endpoint):
     """Return a safe unavailable response when metadata.db vanishes."""
@@ -250,6 +260,20 @@ def test_invalid_opds_prefix_is_rejected(prefix):
     """Reject prefixes that are not safe application URL paths."""
     with pytest.raises(ValidationError):
         Config(opds_prefix=prefix)
+
+
+@pytest.mark.parametrize("page_size", [1, 100])
+def test_page_size_boundaries_are_accepted(page_size):
+    """Accept the inclusive configured page-size boundaries."""
+    assert Config(page_size=page_size).page_size == page_size
+
+
+@pytest.mark.parametrize("page_size", ["invalid", "0", "-1", "101"])
+def test_invalid_page_size_environment_values_are_rejected(monkeypatch, page_size):
+    """Reject malformed and out-of-range PAGE_SIZE environment values."""
+    monkeypatch.setenv("PAGE_SIZE", page_size)
+    with pytest.raises(ValidationError):
+        Config(_env_file=None)
 
 
 def test_custom_opds_prefix_is_used_by_routes_and_generated_links(client_factory):

--- a/tests/test_library_path_confinement.py
+++ b/tests/test_library_path_confinement.py
@@ -1,5 +1,6 @@
 """Integration tests for confining Calibre-controlled filesystem paths."""
 
+import logging
 import sqlite3
 from pathlib import Path
 
@@ -7,8 +8,9 @@ import aiosqlite
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
-from opds_server.core.config import Config, get_config
+from opds_server.core.config import Config
 from opds_server.db.access import get_db_path
 from opds_server.main import create_app
 
@@ -17,7 +19,6 @@ def make_client(library: Path) -> TestClient:
     """Create an isolated client configured to use the supplied library."""
     config = Config(calibre_library_path=library)
     app = create_app(config)
-    app.dependency_overrides[get_config] = lambda: config
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -176,3 +177,43 @@ def test_locked_database_returns_stable_unavailable_response(
         "Calibre database unavailable",
     )
     assert "locked" not in response.text
+
+
+@pytest.mark.parametrize("path", ["", ".", "relative/library"])
+def test_relative_library_paths_are_rejected(path: str):
+    """Reject empty and relative library paths during configuration."""
+    with pytest.raises(ValidationError):
+        Config(calibre_library_path=path)
+
+
+def test_readiness_recovers_without_restarting(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    """Stay live and follow database availability changes after startup."""
+    library = tmp_path / "late-library"
+    app = create_app(Config(calibre_library_path=library))
+
+    caplog.set_level(logging.WARNING, logger="uvicorn.error")
+    with TestClient(app, raise_server_exceptions=False) as client:
+        assert "Starting with Calibre database unavailable" in caplog.text
+        health = client.get("/healthz")
+        assert (health.status_code, health.text) == (200, "ok")
+        assert client.get("/ready").status_code == 503
+
+        library.mkdir()
+        sqlite3.connect(library / "metadata.db").close()
+        ready = client.get("/ready")
+        assert (ready.status_code, ready.text) == (200, "ok")
+
+        (library / "metadata.db").unlink()
+        response = client.get("/ready")
+        assert (response.status_code, response.text) == (
+            503,
+            "Calibre database unavailable",
+        )
+
+
+def test_missing_absolute_library_is_valid_configuration(tmp_path: Path):
+    """Allow an absolute library path to be mounted after configuration."""
+    config = Config(calibre_library_path=tmp_path / "not-mounted")
+    assert config.calibre_library_path == tmp_path / "not-mounted"


### PR DESCRIPTION
- bound PAGE_SIZE to 1-100 and require an absolute library path
- preserve liveness while rechecking readiness without cached state
- use one consistent configuration instance across the application
- document behavior and cover startup and readiness transitions with tests
