### PR TITLE
fix: omit navigation from empty pages

### DIFF
--- a/src/opds_server/db/access.py
+++ b/src/opds_server/db/access.py
@@ -269,7 +269,7 @@ async def select_books(
             books = await cursor.fetchall()
 
     has_next = len(books) > limit
-    has_previous = offset > 0
+    has_previous = offset > 0 and bool(books)
 
     books_dict = await add_authors(books[:limit], config)
     await add_files(books_dict, config)
@@ -317,7 +317,7 @@ async def get_authors(page: int, config: Config) -> tuple[list, bool, bool]:
             authors = await cursor.fetchall()
 
     has_next = len(authors) > limit
-    has_previous = offset > 0
+    has_previous = offset > 0 and bool(authors)
 
     return authors[:limit], has_previous, has_next
 

--- a/tests/test_catalog_endpoints.py
+++ b/tests/test_catalog_endpoints.py
@@ -112,7 +112,16 @@ def test_title_feed_paginates_at_boundaries(catalog_client):
     assert len(entries(second)) == 2
     assert links(second, "previous") and not links(second, "next")
     assert not entries(beyond)
-    assert links(beyond, "previous") and not links(beyond, "next")
+    assert not links(beyond, "previous") and not links(beyond, "next")
+
+
+def test_author_feed_omits_navigation_beyond_last_page(catalog_client):
+    """Omit pagination links when an author page contains no entries."""
+    _, client = catalog_client
+    beyond = parse_atom(client.get("/opds/by-author?page=2"))
+
+    assert not entries(beyond)
+    assert not links(beyond, "previous") and not links(beyond, "next")
 
 
 def test_author_navigation_detail_and_authorless_books(catalog_client):


### PR DESCRIPTION
- Suppress previous links when paginated book or author queries return no rows.
- Cover out-of-range title and author feeds with regression tests.
