### PR TITLE
fix: bound catalog pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ that `/healthz` can continue to report process liveness. `/ready` checks the
 library on every request and returns `503 Calibre database unavailable` until
 `metadata.db` can be accessed.
 
+## Pagination
+
+Catalog feeds use page numbers from 1 through 10,000 and offset pagination.
+Each request reads the current Calibre database, so books added or removed
+between page requests can cause entries to be repeated or skipped during a
+traversal. Keyset pagination is deferred unless benchmarks on large libraries
+show that changing the page-number interface would provide a material benefit.
+
 ## Installation / Run
 
 ### Docker

--- a/src/opds_server/api/catalog.py
+++ b/src/opds_server/api/catalog.py
@@ -1,5 +1,6 @@
 import re
 import unicodedata
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, Response
 from fastapi.responses import FileResponse
@@ -17,6 +18,10 @@ from opds_server.services.opds import (
 )
 
 router = APIRouter()
+
+# Keep offset scans within a documented operational bound for every feed.
+MAX_PAGE_NUMBER = 10_000
+PageNumber = Annotated[int, Query(ge=1, le=MAX_PAGE_NUMBER)]
 
 
 def title_to_filename(title: str, extension: str) -> str:
@@ -72,7 +77,7 @@ def get_opensearch(config: Config = Depends(get_config)) -> Response:
 
 @router.get("/search")
 async def search(
-    q: str, page: int = Query(1, ge=1), config: Config = Depends(get_config)
+    q: str, page: PageNumber = 1, config: Config = Depends(get_config)
 ) -> Response:
     xml = await generate_book_search_feed(q, page, config)
     return Response(content=xml, media_type="application/atom+xml; charset=utf-8")
@@ -85,32 +90,28 @@ def root_main(config: Config = Depends(get_config)):
 
 
 @router.get("/by-newest", response_class=Response)
-async def root_by_newest(
-    page: int = Query(1, ge=1), config: Config = Depends(get_config)
-):
+async def root_by_newest(page: PageNumber = 1, config: Config = Depends(get_config)):
     xml = await generate_newest_feed(page, config)
     return Response(content=xml, media_type="application/atom+xml; charset=utf-8")
 
 
 @router.get("/by-title", response_class=Response)
-async def root_by_title(
-    page: int = Query(1, ge=1), config: Config = Depends(get_config)
-):
+async def root_by_title(page: PageNumber = 1, config: Config = Depends(get_config)):
     xml = await generate_title_feed(page, config)
     return Response(content=xml, media_type="application/atom+xml; charset=utf-8")
 
 
 @router.get("/by-author")
-async def root_by_author(
-    page: int = Query(1, ge=1), config: Config = Depends(get_config)
-):
+async def root_by_author(page: PageNumber = 1, config: Config = Depends(get_config)):
     xml = await generate_by_author_feed(page, config)
     return Response(content=xml, media_type="application/atom+xml; charset=utf-8")
 
 
 @router.get("/author/{author_id}")
 async def get_author_books(
-    author_id: int, page: int = Query(1, ge=1), config: Config = Depends(get_config)
+    author_id: int,
+    page: PageNumber = 1,
+    config: Config = Depends(get_config),
 ):
     xml = await generate_author_feed(author_id, page, config)
     return Response(content=xml, media_type="application/atom+xml; charset=utf-8")

--- a/tests/test_catalog_endpoints.py
+++ b/tests/test_catalog_endpoints.py
@@ -115,6 +115,60 @@ def test_title_feed_paginates_at_boundaries(catalog_client):
     assert not links(beyond, "previous") and not links(beyond, "next")
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/opds/search?q=book&page=10001",
+        "/opds/by-newest?page=10001",
+        "/opds/by-title?page=10001",
+        "/opds/by-author?page=10001",
+        "/opds/author/1?page=10001",
+    ],
+)
+def test_paginated_feeds_reject_pages_above_the_public_limit(catalog_client, path):
+    """Reject pathological offsets before querying any paginated feed."""
+    _, client = catalog_client
+
+    assert client.get(path).status_code == 422
+
+
+def test_maximum_page_returns_a_valid_empty_feed(catalog_client):
+    """Accept the inclusive page limit and preserve empty-feed behavior."""
+    _, client = catalog_client
+    feed = parse_atom(client.get("/opds/by-title?page=10000"))
+
+    assert not entries(feed)
+    assert not links(feed, "previous") and not links(feed, "next")
+
+
+def test_offset_pagination_reads_live_changes_between_requests(client_factory):
+    """Read the current dataset while accepting offset traversal duplicates."""
+    library, client = client_factory(page_size=2)
+    first = parse_atom(client.get("/opds/by-title?page=1"))
+    first_titles = [
+        entry.findtext("atom:title", namespaces=NS) for entry in entries(first)
+    ]
+
+    with sqlite3.connect(library / "metadata.db") as connection:
+        # Insert before the first page so the second offset moves over a book
+        # that the client already received.
+        connection.execute(
+            """
+            INSERT INTO books (id, title, sort, last_modified, path)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (5, "New First Book", "000 First", "2024-01-05 12:00:00+00:00", "New"),
+        )
+
+    second = parse_atom(client.get("/opds/by-title?page=2"))
+    second_titles = [
+        entry.findtext("atom:title", namespaces=NS) for entry in entries(second)
+    ]
+
+    assert first_titles == ["100% Unicode книга", "A <Practical> Book"]
+    assert second_titles == ["A <Practical> Book", "Authorless"]
+
+
 def test_catalog_ordering_uses_calibre_sort_fields_and_id_tie_breakers(
     client_factory,
 ):


### PR DESCRIPTION
- reject catalog page numbers above 10,000 across every paginated feed
- document retained offset pagination and live-library traversal behavior
- cover upper bounds and changing datasets with integration tests
