### PR TITLE
ci: gate image builds on verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,29 @@ concurrency:
   group: docker-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install verification tools
+        run: python -m pip install poetry==2.4.1 ruff==0.12.10
+      - name: Install locked dependencies
+        run: poetry install --no-interaction --no-ansi
+      - name: Validate package metadata and lock file
+        run: poetry check --lock
+      - name: Check lint
+        run: ruff check .
+      - name: Check formatting
+        run: ruff format --check .
+      - name: Run tests
+        run: poetry run pytest
   docker:
+    needs: verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/src/opds_server/db/access.py
+++ b/src/opds_server/db/access.py
@@ -95,7 +95,10 @@ async def connect_db(config: Config) -> AsyncIterator[aiosqlite.Connection]:
 async def check_library_availability(config: Config) -> None:
     """Verify that the configured Calibre database can answer a query."""
     async with connect_db(config) as conn:
-        await conn.execute("SELECT 1")
+        # Reading SQLite metadata forces the database file to be parsed. A
+        # constant-only query can succeed without detecting a malformed file.
+        async with conn.execute("SELECT name FROM sqlite_master LIMIT 1") as cursor:
+            await cursor.fetchone()
 
 
 async def get_book_title(book_id: int, config: Config) -> str:


### PR DESCRIPTION
- validate locked dependencies and package metadata with Poetry
- enforce Ruff linting and formatting checks on Python 3.12
- run the test suite before Docker image builds
