### PR TITLE
chore(release): prepare version 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,47 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.1.3] - 2026-07-30
+
+### Fixed
+
+- Bound catalog pagination to prevent requests beyond the final page (#23).
+- Made catalog ordering deterministic (#22).
+- Omitted navigation links from empty catalog pages (#21).
+- Validated configuration during startup readiness checks (#20).
+- Handled invalid Calibre timestamps (#19).
+- Returned HTTP 503 when the Calibre database is unavailable (#18).
+- Honored the configured catalog prefix in OPDS feeds (#17).
+
 ## [0.1.2] - 2026-07-19
 
-### 🔒 Security
+### Security
 
-- Prevent book download requests from accessing files outside the configured Calibre library (#15).
+- Prevented book download requests from accessing files outside the configured Calibre library (#15).
 
 ## [0.1.1] - 2025-08-27
 
-### 📚 Documentation
+### Changed
 
-- readme: Update features
+- Updated the documented feature list.
+- Added the MIT license and declared it in the project metadata.
+- Added CI concurrency to cancel superseded builds (#13).
+- Configured CI to build container images from version tags.
 
-### ⚙️ Miscellaneous Tasks
+## [0.1.0] - 2025-08-26
 
-- license* Add MIT license and declare in pyproject
-- ci: Add concurrency to cancel in-progress builds (#13)
-- ci: Trigger Docker builds on version tags
+### Added
 
-## [0.1.0] — 2025-08-26
-Initial release
+- Initial release.
 
+[Unreleased]: https://github.com/victor1234/opds-server/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/victor1234/opds-server/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/victor1234/opds-server/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/victor1234/opds-server/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/victor1234/opds-server/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ show that changing the page-number interface would provide a material benefit.
 ```bash
 docker run --rm -p 9000:8000 \
   -v /path_to_calibre_directory:/app/calibre:ro \
-  ghcr.io/victor1234/opds-server:0.1.2
+  ghcr.io/victor1234/opds-server:0.1.3
 ```
 
 ### Docker Compose
 ```yaml
 services:
   opds:
-    image: ghcr.io/victor1234/opds-server:0.1.2
+    image: ghcr.io/victor1234/opds-server:0.1.3
     ports:
       - "9000:8000"
     volumes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opds-server"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = [
     {name = "Kataev Viktor",email = "kataev.victor.1234@gmail.com"}


### PR DESCRIPTION
- Bump the project version to 0.1.3.
- Add curated Keep a Changelog release notes.
